### PR TITLE
Robustness improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
-_obuild
+_opam
+_obuild/
 *~
 _build
 autoconf

--- a/libs/ez-api/ezAPIServer.ml
+++ b/libs/ez-api/ezAPIServer.ml
@@ -103,16 +103,17 @@ let dispatch s (io, _conn) req body =
            reply_none 200
          | API dir, _ ->
            let content =
-             match request.req_body with
-             | BodyString (Some "application/x-www-form-urlencoded", content) ->
-               EzAPI.add_params request ( EzUrl.decode_args content );
-               None
-             | BodyString (Some "application/json", content) ->
-               Some (Ezjsonm.from_string content)
-             | BodyString (_, content) ->
-               try
-                 Some (Ezjsonm.from_string content)
-               with _ -> None
+             match meth, request.req_body with
+             | `GET, BodyString (_, "") -> None
+             | _, BodyString (Some "application/x-www-form-urlencoded", content) ->
+                EzAPI.add_params request ( EzUrl.decode_args content );
+                None
+             | _, BodyString (Some "application/json", content) ->
+                Some (Ezjsonm.from_string content)
+             | _, BodyString (_, content) ->
+                try
+                  Some (Ezjsonm.from_string content)
+                with _ -> None
            in
            RestoDirectory1.lookup dir.meth_GET request path >>= fun handler ->
            handler content

--- a/libs/ez-api/ezAPIServer.ml
+++ b/libs/ez-api/ezAPIServer.ml
@@ -132,6 +132,8 @@ let dispatch s (io, _conn) req body =
        | EzContentError (code, json) ->
          reply_raw_json code json
        | Not_found -> reply_none 404
+       | RestoDirectory1.Cannot_parse (descr, msg, rpath) ->
+         reply_answer (RestoDirectory1.response_of_cannot_parse descr msg rpath)
        | exn ->
          Printf.eprintf "In %s: exception %s\n%!"
            local_path (Printexc.to_string exn);

--- a/libs/ez-api/ezAPIServerHttpAf.ml
+++ b/libs/ez-api/ezAPIServerHttpAf.ml
@@ -288,13 +288,14 @@ let connection_handler : server -> Unix.sockaddr -> Lwt_unix.file_descr -> unit 
                     handler None >>= fun _answer -> reply_none 200
                   | API dir, _ ->
                     let content =
-                      match ez_request.req_body with
-                      | BodyString (Some "application/x-www-form-urlencoded", content) ->
+                      match request.Request.meth, ez_request.req_body with
+                      | `GET, BodyString (_, "") -> None
+                      | _, BodyString (Some "application/x-www-form-urlencoded", content) ->
                         EzAPI.add_params ez_request ( EzUrl.decode_args content );
                         None
-                      | BodyString (Some "application/json", content) ->
+                      | _, BodyString (Some "application/json", content) ->
                         Some (Ezjsonm.from_string content)
-                      | BodyString (_, content) ->
+                      | _, BodyString (_, content) ->
                         try
                           Some (Ezjsonm.from_string content)
                         with _ -> None

--- a/libs/ez-api/ezAPIServerHttpAf.ml
+++ b/libs/ez-api/ezAPIServerHttpAf.ml
@@ -315,6 +315,10 @@ let connection_handler : server -> Unix.sockaddr -> Lwt_unix.file_descr -> unit 
                    | EzContentError (code, json) ->
                      reply_raw_json code json
                    | Not_found -> reply_none 404
+                   | RestoDirectory1.Cannot_parse (descr, msg, rpath) ->
+                     reply_answer
+                       (RestoDirectory1.response_of_cannot_parse
+                          descr msg rpath)
                    | exn ->
                      Printf.eprintf "In %s: exception %s\n%!"
                        local_path (Printexc.to_string exn);

--- a/libs/ez-api/ezAPIServerUtils.ml
+++ b/libs/ez-api/ezAPIServerUtils.ml
@@ -21,8 +21,8 @@ let verbose =
     let s = Sys.getenv "EZAPISERVER" in
     try
       int_of_string s
-    with _ -> 2
-  with _ -> 1
+    with _ -> 1
+  with _ -> 0
 
 
 exception EzRawReturn of string

--- a/libs/ez-api/ezAPIServerUtils.ml
+++ b/libs/ez-api/ezAPIServerUtils.ml
@@ -13,8 +13,8 @@ let empty = {
   meth_OPTIONS = RestoDirectory1.empty;
 }
 
-let return x = RestoDirectory1.Answer.return x
-let return_raw s = RestoDirectory1.Answer.return_raw s
+let return ?code x = RestoDirectory1.Answer.return ?code x
+let return_raw ?code s = RestoDirectory1.Answer.return_raw ?code s
 
 let verbose =
   try

--- a/libs/ez-api/restoDirectory1.ml
+++ b/libs/ez-api/restoDirectory1.ml
@@ -423,6 +423,18 @@ module Make(Repr : Json_repr.Repr) = struct
           | CustomDirectory _ -> Lwt.fail Not_found
         end
 
+  let response_of_cannot_parse descr msg rpath =
+    let body =
+      Repr.repr @@
+      `O [ "error", Repr.repr @@
+           `String (Printf.sprintf "Cannot parse path argument %s" descr.Arg.name) ;
+           "path", Repr.repr @@
+           `String (String.concat "/" (List.rev rpath));
+           "msg", Repr.repr @@
+           `String msg;
+         ] in
+    { code = 400 ; body = Single body }
+
   let describe_directory
     : type a _p.
       ?recurse:bool -> a directory -> a -> string list -> Description.directory_descr Lwt.t

--- a/libs/ez-api/restoDirectory1.ml
+++ b/libs/ez-api/restoDirectory1.ml
@@ -66,14 +66,14 @@ module Answer = struct
       body : 'a output ;
     }
 
-  let ok json = { code = 200 ; body = Single json }
-  let return json = Lwt.return { code = 200 ; body = Single json }
+  let ok ?(code=200) json = { code ; body = Single json }
+  let return ?code json = Lwt.return (ok ?code json)
 
-  let ok_raw s = { code = 200 ; body = Single_raw s }
-  let return_raw s = Lwt.return (ok_raw s)
+  let ok_raw ?(code=200) s = { code ; body = Single_raw s }
+  let return_raw ?code s = Lwt.return (ok_raw ?code s)
 
-  let ok_stream st = { code = 200 ; body = Stream st }
-  let return_stream st = Lwt.return { code = 200 ; body = Stream st }
+  let ok_stream ?(code=200) st = { code ; body = Stream st }
+  let return_stream ?code st = Lwt.return (ok_stream ?code st)
 
   let map (type a) (type b) (f:a -> b) (({ code ; body = _ } as ans) : a answer) : b answer =
     match ans.body with

--- a/libs/ez-api/restoDirectory1.mli
+++ b/libs/ez-api/restoDirectory1.mli
@@ -68,6 +68,9 @@ module Make (Repr : Json_repr.Repr) : sig
     'prefix directory -> 'prefix -> string list ->
     (Repr.value option -> Repr.value Answer.answer Lwt.t) Lwt.t
 
+  val response_of_cannot_parse :
+    Arg.descr -> string -> string list ->
+    Repr.value Answer.answer
 
   (** Registring handler in service tree. *)
   val register:

--- a/libs/ez-api/restoDirectory1.mli
+++ b/libs/ez-api/restoDirectory1.mli
@@ -29,12 +29,12 @@ module Answer : sig
     shutdown: unit -> unit ;
   }
 
-  val ok: 'a -> 'a answer
-  val ok_raw: string -> 'a answer
-  val ok_stream: 'a stream -> 'a answer
-  val return: 'a -> 'a answer Lwt.t
-  val return_raw: string -> 'a answer Lwt.t
-  val return_stream: 'a stream -> 'a answer Lwt.t
+  val ok: ?code:int -> 'a -> 'a answer
+  val ok_raw: ?code:int -> string -> 'a answer
+  val ok_stream: ?code:int -> 'a stream -> 'a answer
+  val return: ?code:int -> 'a -> 'a answer Lwt.t
+  val return_raw: ?code:int -> string -> 'a answer Lwt.t
+  val return_stream: ?code:int -> 'a stream -> 'a answer Lwt.t
 
 end
 


### PR DESCRIPTION
- Don't fail on GET request with an empty content
- User of library can specify return code in his responses
- Return code 400 when a path argument cannot be decoded