### PR TITLE
fix asynchronous curl_lwt

### DIFF
--- a/src/request/unix/curl/dune
+++ b/src/request/unix/curl/dune
@@ -25,7 +25,7 @@
  (public_name ez_api.curl_lwt)
  (optional)
  (modules ezCurl_lwt)
- (libraries ezCurl_common ezRequest_lwt))
+ (libraries ezCurl_multi))
 
 (library
  (name ezCurl_lwt_i)

--- a/src/request/unix/curl/ezCurl_lwt.ml
+++ b/src/request/unix/curl/ezCurl_lwt.ml
@@ -8,30 +8,4 @@
 (*                                                                        *)
 (**************************************************************************)
 
-let make ?msg ?meth ?content ?content_type ?headers url =
-  EzCurl_common.log ?meth url msg;
-  if !Verbose.v land 2 <> 0 then Format.printf "sent:\n%s@." (Option.value ~default:"" content);
-  let r () =
-    let r, c = EzCurl_common.init ?meth ?content ?content_type ?headers url in
-    Curl.perform c;
-    let rc = Curl.get_responsecode c in
-    Curl.cleanup c;
-    let data = Buffer.contents r in
-    EzCurl_common.log ~meth:("RECV " ^ string_of_int rc) url msg;
-    if !Verbose.v land 1 <> 0 then Format.printf "received:\n%s@." data;
-    if rc >= 200 && rc < 300 then Lwt.return_ok data
-    else Lwt.return_error (rc, Some data) in
-  Lwt.catch r (function
-      | Curl.CurlException (_, i, s) -> Lwt.return (Error (i, Some s))
-      | exn -> Lwt.return (Error (-1, Some (Printexc.to_string exn))))
-
-module Interface = struct
-  let get ?(meth="GET") ?headers ?msg url =
-    make ?msg ~meth ?headers url
-
-  let post ?(meth="POST") ?(content_type="application/json") ?(content="{}") ?headers
-      ?msg url =
-    make ?msg ~meth ?headers ~content ~content_type url
-end
-
-include EzRequest_lwt.Make(Interface)
+include EzCurl_multi


### PR DESCRIPTION
Due to some incomprehension of curl.lwt I had provided 2 implementations of curl with lwt but it was a mistake and it is misleading (ie ez_api.curl_lwt was blocking).
Now ez_api.curl_lwt is just an alias of ez_api.curl_multi